### PR TITLE
Change instanceof to typeof to allow symlinking

### DIFF
--- a/packages/client/src/rx/FlowableAdapter.js
+++ b/packages/client/src/rx/FlowableAdapter.js
@@ -36,9 +36,9 @@ export default function toObservable(
   rsocketType: Flowable<T> | Single<T>,
   batchSize?: number,
 ) {
-  if (rsocketType instanceof Flowable) {
+  if (rsocketType typeof Flowable) {
     return from(new ObservableFlowable(rsocketType, batchSize));
-  } else if (rsocketType instanceof Single) {
+  } else if (rsocketType typeof Single) {
     return from(new ObservableSingle(rsocketType));
   } else {
     console.log('Unrecognized type: ' + rsocketType);


### PR DESCRIPTION
The problem: symlinked versions of proteus-js-client fail when using toObservable because the Flowable object referenced in the library has a different prototype chain from the Flowable in the symlinked project.

My solution: It looks like typeof does actual type inference in Flow: https://flow.org/en/docs/types/typeof/ so I think changing instanceof to typeof should allow this to work.