### PR TITLE
Bugfix: remove instanceof for symlinking

### DIFF
--- a/packages/client/src/rx/FlowableAdapter.js
+++ b/packages/client/src/rx/FlowableAdapter.js
@@ -36,9 +36,9 @@ export default function toObservable(
   rsocketType: Flowable<T> | Single<T>,
   batchSize?: number,
 ) {
-  if (rsocketType instanceof Flowable) {
+  if (rsocketType.constructor.name === 'Flowable') {
     return from(new ObservableFlowable(rsocketType, batchSize));
-  } else if (rsocketType instanceof Single) {
+  } else if (rsocketType.constructor.name === 'Single') {
     return from(new ObservableSingle(rsocketType));
   } else {
     console.log('Unrecognized type: ' + rsocketType);


### PR DESCRIPTION
Hat tip @OlegDokuka - this is a hacky workaround for when instanceof fails, notably when proteus-js-client is symlinked into another project.